### PR TITLE
Overview method

### DIFF
--- a/date.go
+++ b/date.go
@@ -1,0 +1,48 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// RFC5322 date parsing. Copied from net/mail Go standard
+// library package.
+package nntp
+
+import "errors"
+import "time"
+
+// Layouts suitable for passing to time.Parse.
+// These are tried in order.
+var dateLayouts []string
+
+func init() {
+	// Generate layouts based on RFC 5322, section 3.3.
+
+	dows := [...]string{"", "Mon, "}   // day-of-week
+	days := [...]string{"2", "02"}     // day = 1*2DIGIT
+	years := [...]string{"2006", "06"} // year = 4*DIGIT / 2*DIGIT
+	seconds := [...]string{":05", ""}  // second
+	// "-0700 (MST)" is not in RFC 5322, but is common.
+	zones := [...]string{"-0700", "MST", "-0700 (MST)"} // zone = (("+" / "-") 4DIGIT) / "GMT" / ...
+
+	for _, dow := range dows {
+		for _, day := range days {
+			for _, year := range years {
+				for _, second := range seconds {
+					for _, zone := range zones {
+						s := dow + day + " Jan " + year + " 15:04" + second + " " + zone
+						dateLayouts = append(dateLayouts, s)
+					}
+				}
+			}
+		}
+	}
+}
+
+func parseDate(date string) (time.Time, error) {
+	for _, layout := range dateLayouts {
+		t, err := time.Parse(layout, date)
+		if err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, errors.New("date cannot be parsed")
+}

--- a/nntp_test.go
+++ b/nntp_test.go
@@ -155,6 +155,26 @@ Body.
 		t.Fatal("newgroups shouldn't error " + err.Error())
 	}
 
+	// Overview
+	overviews, err := conn.Overview(10, 11)
+	if err != nil {
+		t.Fatal("overview shouldn't error: " + err.Error())
+	}
+	expectedOverviews := []MessageOverview{
+		MessageOverview{10, "Subject10", "Author <author@server>", time.Date(2003, 10, 18, 18, 0, 0, 0, time.FixedZone("", 1800)), "<d@e.f>", []string{}, 1000, 9, []string{}},
+		MessageOverview{11, "Subject11", "", time.Date(2003, 10, 18, 19, 0, 0, 0, time.FixedZone("", 1800)), "<e@f.g>", []string{"<d@e.f>", "<a@b.c>"}, 2000, 18, []string{"Extra stuff"}},
+	}
+
+	if len(overviews) != len(expectedOverviews) {
+		t.Fatalf("returned %d overviews, expected %d", len(overviews), len(expectedOverviews))
+	}
+
+	for i, o := range overviews {
+		if fmt.Sprint(o) != fmt.Sprint(expectedOverviews[i]) {
+			t.Fatalf("in place of %dth overview expected %v, got %v", i, expectedOverviews[i], o)
+		}
+	}
+
 	if err = conn.Quit(); err != nil {
 		t.Fatal("Quit shouldn't error: " + err.Error())
 	}
@@ -213,6 +233,10 @@ Fin.
 .
 231 New newsgroups follow
 .
+224 Overview information for 10-11 follows
+10	Subject10	Author <author@server>	Sat, 18 Oct 2003 18:00:00 +0030	<d@e.f>		1000	9
+11	Subject11		18 Oct 2003 19:00:00 +0030	<e@f.g>	<d@e.f> <a@b.c>	2000	18	Extra stuff
+.
 205 Bye!
 `
 
@@ -232,5 +256,6 @@ HEAD 101
 BODY 1
 NEWNEWS gmane.comp.lang.go.general 20100301 000000 GMT
 NEWGROUPS 20100301 000000 GMT
+OVER 10-11
 QUIT
 `


### PR DESCRIPTION
This pull request adds an Overview method that invokes OVER command.

The interface is somewhat limited (we can only ask for message number range). I don't see much use for the parts that are inaccessible (one-sided range can be substituted by a very small/large range boundary; asking for message id doesn't seem to have much advantage over HEAD).
