### PR TITLE
Spaces at the end of lines should not be stripped

### DIFF
--- a/nntp.go
+++ b/nntp.go
@@ -682,7 +682,7 @@ func readLineBytes(b *bufio.Reader) (p []byte, err error) {
 	// Chop off trailing white space.
 	var i int
 	for i = len(p); i > 0; i-- {
-		if c := p[i-1]; c != ' ' && c != '\r' && c != '\t' && c != '\n' {
+		if c := p[i-1]; c != '\r' && c != '\t' && c != '\n' {
 			break
 		}
 	}


### PR DESCRIPTION
There are some posts with XML in the headers. When you strip the leading spaces you will receive invalid XML.
