### PR TITLE
Enhancement/Fixes for the Overview function

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ nntp.go
 
 An NNTP (news) Client package for go (golang). Forked from [nntp-go](http://code.google.com/p/nntp-go/) to bring it up to date.
 
+Updates
+-------
+- added IHAVE command
+- use XOVER if OVER is unrecognized
+- set overview.Bytes to 0 if bytes value is empty
+- set overview.Lines to 0 if lines value is empty
+
 Example
 -------
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Tensai75/nntp
 
-go 1.22.2
+go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Tensai75/nntp
+
+go 1.22.2

--- a/nntp.go
+++ b/nntp.go
@@ -370,8 +370,10 @@ type MessageOverview struct {
 // begin and end, inclusive.
 func (c *Conn) Overview(begin, end int) ([]MessageOverview, error) {
 	if code, _, err := c.cmd(224, "OVER %d-%d", begin, end); err != nil {
-		// if error is "400 Unrecognized command" try the XOVER command
-		if code == 400 {
+		// if error is "500 Unknown Command" (correct response according to RFC 3977), or
+		// if error is "400 Unrecognized command" or (wrong response sent by newshositng, eweka, tweaknews and maybe others...)
+		// try the XOVER command
+		if code == 500 || code == 400 {
 			if _, _, err := c.cmd(224, "XOVER %d-%d", begin, end); err != nil {
 				return nil, err
 			}

--- a/nntp.go
+++ b/nntp.go
@@ -659,6 +659,25 @@ func (c *Conn) Post(a *Article) error {
 	return c.RawPost(&articleReader{a: a})
 }
 
+// RawIHave reads a text-formatted article from r and presents it to the server with the IHAVE command.
+func (c *Conn) RawIHave(r io.Reader) error {
+	if _, _, err := c.cmd(3, "IHAVE"); err != nil {
+		return err
+	}
+	if err := c.sendLines(r); err != nil {
+		return err
+	}
+	if _, _, err := c.cmd(235, "."); err != nil {
+		return err
+	}
+	return nil
+}
+
+// IHave presents an article to the server with the IHAVE command.
+func (c *Conn) IHave(a *Article) error {
+	return c.RawIHave(&articleReader{a: a})
+}
+
 // Quit sends the QUIT command and closes the connection to the server.
 func (c *Conn) Quit() error {
 	_, _, err := c.cmd(0, "QUIT")

--- a/nntp.go
+++ b/nntp.go
@@ -707,7 +707,7 @@ func (c *Conn) IHave(a *Article) error {
 
 // Quit sends the QUIT command and closes the connection to the server.
 func (c *Conn) Quit() error {
-	_, _ = io.ReadAll(c.r)
+	c.r.Discard(c.r.Buffered())
 	_, _, err := c.cmd(0, "QUIT")
 	c.conn.Close()
 	c.close = true

--- a/nntp.go
+++ b/nntp.go
@@ -766,7 +766,7 @@ func readKeyValue(b *bufio.Reader) (key, value string, err error) {
 	}
 
 	key = string(line[0:i])
-	if strings.Index(key, " ") >= 0 {
+	if strings.Contains(key, " ") {
 		// Key field has space - no good.
 		goto Malformed
 	}

--- a/nntp.go
+++ b/nntp.go
@@ -622,9 +622,7 @@ func (c *Conn) sendLines(r io.Reader) error {
 		if eof && len(line) == 0 {
 			break
 		}
-		if strings.HasSuffix(line, "\n") {
-			line = line[0 : len(line)-1]
-		}
+		line = strings.TrimSuffix(line, "\n")
 		var prefix string
 		if strings.HasPrefix(line, ".") {
 			prefix = "."

--- a/nntp.go
+++ b/nntp.go
@@ -707,6 +707,7 @@ func (c *Conn) IHave(a *Article) error {
 
 // Quit sends the QUIT command and closes the connection to the server.
 func (c *Conn) Quit() error {
+	_, _ = io.ReadAll(c.r)
 	_, _, err := c.cmd(0, "QUIT")
 	c.conn.Close()
 	c.close = true

--- a/nntp.go
+++ b/nntp.go
@@ -389,7 +389,7 @@ func (c *Conn) Overview(begin, end int) ([]MessageOverview, error) {
 
 	result := make([]MessageOverview, 0, len(lines))
 	for _, line := range lines {
-		overview, err := c.ParseOverviewLine(line)
+		overview, err := ParseOverviewLine(line)
 		if err != nil {
 			return nil, err
 		}
@@ -398,7 +398,7 @@ func (c *Conn) Overview(begin, end int) ([]MessageOverview, error) {
 	return result, nil
 }
 
-func (c *Conn) ParseOverviewLine(line string) (MessageOverview, error) {
+func ParseOverviewLine(line string) (MessageOverview, error) {
 	err := error(nil)
 	overview := MessageOverview{}
 	ss := strings.SplitN(strings.TrimSpace(line), "\t", 9)

--- a/nntp.go
+++ b/nntp.go
@@ -370,8 +370,15 @@ type MessageOverview struct {
 // Overview returns overviews of all messages in the current group with message number between
 // begin and end, inclusive.
 func (c *Conn) Overview(begin, end int) ([]MessageOverview, error) {
-	if _, _, err := c.cmd(224, "OVER %d-%d", begin, end); err != nil {
-		return nil, err
+	if code, _, err := c.cmd(224, "OVER %d-%d", begin, end); err != nil {
+		// if error is "400 Unrecognized command" try the XOVER command
+		if code == 400 {
+			if _, _, err := c.cmd(224, "XOVER %d-%d", begin, end); err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 
 	lines, err := c.readStrings()

--- a/nntp.go
+++ b/nntp.go
@@ -399,9 +399,13 @@ func (c *Conn) Overview(begin, end int) ([]MessageOverview, error) {
 		}
 		overview.MessageId = ss[4]
 		overview.References = strings.Split(ss[5], " ") // Message-Id's contain no spaces, so this is safe.
-		overview.Bytes, err = strconv.Atoi(ss[6])
-		if err != nil {
-			return nil, ProtocolError("bad byte count '" + ss[6] + "'in line:" + line)
+		if ss[6] == "" {
+			overview.Bytes = 0
+		} else {
+			overview.Bytes, err = strconv.Atoi(ss[6])
+			if err != nil {
+				return nil, ProtocolError("bad byte count '" + ss[6] + "'in line:" + line)
+			}
 		}
 		overview.Lines, err = strconv.Atoi(ss[7])
 		if err != nil {

--- a/nntp.go
+++ b/nntp.go
@@ -407,9 +407,13 @@ func (c *Conn) Overview(begin, end int) ([]MessageOverview, error) {
 				return nil, ProtocolError("bad byte count '" + ss[6] + "'in line:" + line)
 			}
 		}
-		overview.Lines, err = strconv.Atoi(ss[7])
-		if err != nil {
-			return nil, ProtocolError("bad line count '" + ss[7] + "'in line:" + line)
+		if ss[7] == "" {
+			overview.Lines = 0
+		} else {
+			overview.Lines, err = strconv.Atoi(ss[7])
+			if err != nil {
+				return nil, ProtocolError("bad line count '" + ss[7] + "'in line:" + line)
+			}
 		}
 		overview.Extra = append([]string{}, ss[8:]...)
 		result = append(result, overview)

--- a/nntp_test.go
+++ b/nntp_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -86,7 +85,7 @@ func TestBasics(t *testing.T) {
 	if err != nil {
 		t.Fatal("should be able to fetch the low article: " + err.Error())
 	}
-	body, err := ioutil.ReadAll(a.Body)
+	body, err := io.ReadAll(a.Body)
 	if err != nil {
 		t.Fatal("error reading reader: " + err.Error())
 	}
@@ -142,7 +141,7 @@ Body.
 	if err != nil {
 		t.Fatal("should be able to fetch the low article body" + err.Error())
 	}
-	if _, err = ioutil.ReadAll(r); err != nil {
+	if _, err = io.ReadAll(r); err != nil {
 		t.Fatal("error reading reader: " + err.Error())
 	}
 


### PR DESCRIPTION
In order to use this nntp package in my go project I hade to do some fixes/enhancements in the Overview function to get it to work correctly with my usenet provider:

- The NNTP server only has the newer XOVER command but not the OVER command available, so I added a fallback to try XOVER if OVER is not recognized.
- And some headers returned by the (X)OVER command sometimes have an empty string as lines or bytes values which however should not result in an error. In such cases 0 should be returned as the value for the bytes or lines repectively.

I hope these enhacements/fixes are useful.